### PR TITLE
Patch for gym version 0.21.0 bug

### DIFF
--- a/kits/rl/sb3/train.py
+++ b/kits/rl/sb3/train.py
@@ -56,7 +56,8 @@ class CustomEnvWrapper(gym.Wrapper):
         action = {agent: action}
         obs, _, done, info = self.env.step(action)
         obs = obs[agent]
-        done = done[agent]
+        if type(done) == type({}): done = done[agent]
+        elif type(done) == type(True): done = {agent: done, opp_agent: False}
 
         # we collect stats on teams here. These are useful stats that can be used to help generate reward functions
         stats: StatsStateDict = self.env.state.stats[agent]


### PR DESCRIPTION
I came across this bug in gym: https://github.com/openai/gym/pull/2752
When time limit is triggered, the output is a bool instead of a dict like {'player_0': False, 'player_1': False}

This produces the following error randomly. It appears sooner or later during the training.

~/.conda/envs/lux_ai_s2/lib/python3.7/site-packages/gym/wrappers/time_limit.py in step(self, action)
     16             self._elapsed_steps is not None
     17         ), "Cannot call env.step() before calling reset()"
---> 18         observation, reward, done, info = self.env.step(action)
     19         self._elapsed_steps += 1
     20         if self._elapsed_steps >= self._max_episode_steps:

/tmp/ipykernel_13436/3060603165.py in step(self, action)
     57         obs, _, done, info = self.env.step(action)
     58         obs = obs[agent]
---> 59         done = done[agent]
     60 #         if type(done) == type({}): done = done[agent]
     61 #         elif type(done) == type(True): done = {agent: done, opp_agent: False}

TypeError: 'bool' object is not subscriptable

I sugest this patch to avoid that.